### PR TITLE
Components内で利用されてない部分の削除

### DIFF
--- a/src/pages/author/author.ts
+++ b/src/pages/author/author.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { NavController, IonicPage, NavParams } from 'ionic-angular';
 import { WordpressProvider } from '../../providers/wordpress/wordpress';
-import { IPostParams, IPost } from '../../interfaces/wordpress';
+import { IPostParams } from '../../interfaces/wordpress';
 
 @IonicPage({
     segment: 'author/:key',

--- a/src/pages/category/category.ts
+++ b/src/pages/category/category.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { NavController, IonicPage, NavParams } from 'ionic-angular';
 import { WordpressProvider } from '../../providers/wordpress/wordpress';
-import { IPostParams, ICategory } from '../../interfaces/wordpress';
+import { IPostParams } from '../../interfaces/wordpress';
 
 @IonicPage({
     segment: 'category/:key',

--- a/src/pages/tag/tag.ts
+++ b/src/pages/tag/tag.ts
@@ -1,7 +1,7 @@
 import { Component } from '@angular/core';
 import { NavController, IonicPage, NavParams } from 'ionic-angular';
 import { WordpressProvider } from '../../providers/wordpress/wordpress';
-import { IPostParams, ITag } from '../../interfaces/wordpress'
+import { IPostParams } from '../../interfaces/wordpress'
 
 @IonicPage({
     segment: 'tag/:key',


### PR DESCRIPTION
`ionic serve` すると下記のエラーが出ていたので、除去対応しました。

```
[app-scripts] [16:25:36]  tslint: src/pages/author/author.ts, line: 4 
[app-scripts]             'IPost' is declared but its value is never read. 
[app-scripts]        L3:  import { WordpressProvider } from '../../providers/wordpress/wordpress';
[app-scripts]        L4:  import { IPostParams, IPost } from '../../interfaces/wordpress';
[app-scripts] [16:25:36]  tslint: src/pages/category/category.ts, line: 4 
[app-scripts]             'ICategory' is declared but its value is never read. 
[app-scripts]        L3:  import { WordpressProvider } from '../../providers/wordpress/wordpress';
[app-scripts]        L4:  import { IPostParams, ICategory } from '../../interfaces/wordpress';
[app-scripts] [16:25:36]  tslint: src/pages/tag/tag.ts, line: 4 
[app-scripts]             'ITag' is declared but its value is never read. 
[app-scripts]        L3:  import { WordpressProvider } from '../../providers/wordpress/wordpress';
[app-scripts]        L4:  import { IPostParams, ITag } from '../../interfaces/wordpress'

```